### PR TITLE
chore(ci): test all node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - 0.8
   - 0.10
+  - 0.12
+  - 4
+  - node
 services:
   - mongodb


### PR DESCRIPTION
This adds Node 0.12, 4 and latest stable to TravisCI