### PR TITLE
update to latest version of stream-worker

### DIFF
--- a/mongoose-querystream-worker.js
+++ b/mongoose-querystream-worker.js
@@ -7,7 +7,8 @@ QueryStream.prototype.concurrency = function (max) {
   return this;
 };
 
-QueryStream.prototype.work = function (worker, done) {
-  var concurrency = this._concurrency || DEFAULT_CONCURRENCY_LIMIT;
-  return streamWorker(this, concurrency, worker, done);
+QueryStream.prototype.work = function (worker, options, done) {
+  options = options || { };
+  if (!options.concurrency) options.concurrency = this._concurrency || DEFAULT_CONCURRENCY_LIMIT;
+  return streamWorker(this, worker, options, done);
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "bluebird": "~3.3.0",
-    "stream-worker": "~1.0.0"
+    "stream-worker": "~2.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/test/querystream.work.test.js
+++ b/test/querystream.work.test.js
@@ -40,15 +40,16 @@ describe('query stream worker:', function(){
     });
   });
 
-  it('invokes a worker (promise-style) for each doc', function(){
+  it('invokes a worker (promise-style) for each doc', function(done){
     var db = start()
       , P = db.model('PersonForStream', collection)
       , i = 0
 
     return P.find().stream().work(function(doc) {
       i++
-    }).then(function() {
+    }, {promises : true}).then(function() {
       assert.equal(i, names.length);
+      done();
     });
   });
 
@@ -61,7 +62,7 @@ describe('query stream worker:', function(){
       function(doc, done) {
         i++;
         done();
-      },
+      },{promises : false},
       function(err) {
         assert.equal(i, names.length);
         done();
@@ -86,7 +87,7 @@ describe('query stream worker:', function(){
     }
 
     var stream = P.find().stream();
-    stream.concurrency(concurrencyLimit).work(worker, testDone);
+    stream.concurrency(concurrencyLimit).work(worker, {}, testDone);
 
     function checkWorkers () {
       assert(workers.length <= concurrencyLimit, 'the concurrency limit is never exceeded');


### PR DESCRIPTION
- Reworks the `.work` signature to match the new streamworker signature, same defaults
- Updates tests
- Updates package.json with v.2.0.0 of streamworker

This also would require a semver major bump before publishing.