### PR TITLE
Bump mongoose and switch to Cursor API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ pids
 logs
 results
 node_modules
+yarn.lock
 
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
   - 0.12
   - 4
   - node

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ require('mongoose-querystream-worker');
 
 /* Promises: */
 
-Model.find().stream().concurrency(n).work(function (doc) {
-  /* ... work with the doc ... */ 
+Model.find().cursor().concurrency(n).work(function (doc) {
+  /* ... work with the doc ... */
   return doc.save(); /* returns a promise */
 })
 .then(function() {
@@ -20,7 +20,7 @@ Model.find().stream().concurrency(n).work(function (doc) {
 
 /* Callbacks: */
 
-Model.find().stream().concurrency(n).work(
+Model.find().cursor().concurrency(n).work(
   function (doc, done) {
     /* ... work with the doc ... */
   },

--- a/mongoose-querystream-worker.js
+++ b/mongoose-querystream-worker.js
@@ -1,13 +1,13 @@
-var QueryStream = require('mongoose/lib/querystream'),
+var QueryCursor = require('mongoose/lib/querycursor'),
     streamWorker = require('stream-worker'),
     DEFAULT_CONCURRENCY_LIMIT = 10;
 
-QueryStream.prototype.concurrency = function (max) {
+QueryCursor.prototype.concurrency = function (max) {
   this._concurrency = max;
   return this;
 };
 
-QueryStream.prototype.work = function (worker, options, done) {
+QueryCursor.prototype.work = function (worker, options, done) {
   options = options || { };
   if (!options.concurrency) options.concurrency = this._concurrency || DEFAULT_CONCURRENCY_LIMIT;
   return streamWorker(this, worker, options, done);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "gitHead": "a39913da83703f67e608426e275aad9effff8fbc",
   "devDependencies": {
     "mocha": "^2.0.0",
-    "mongoose": "^4.0.0"
+    "mongoose": "^4.5.0"
   },
   "dependencies": {
     "bluebird": "~3.3.0",


### PR DESCRIPTION
Fixes #7.

Users will need mongoose `>=v4.5.0` to update.
