### PR TITLE
add deprecation message to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 mongoose-querystream-worker [![build status](https://secure.travis-ci.org/goodeggs/mongoose-querystream-worker.png)](http://travis-ci.org/goodeggs/mongoose-querystream-worker)
 ===========================
 
+DEPRECATED - In light of [Mongoose QueryStreams](http://mongoosejs.com/docs/api.html#query_Query-stream) being deprecated in favor of  [Mongoose QueryCursors](http://mongoosejs.com/docs/api.html#query_Query-cursor), may as well just depend on [stream-worker](https://github.com/goodeggs/stream-worker) directly, rather than maintaining this lightweight syntatic layer.
+
 Execute an async function per document in a streamed query, pausing the stream when a concurrency limit is saturated.  Think [async.queue](https://github.com/caolan/async#queue) but for [Mongoose QueryStreams](http://mongoosejs.com/docs/api.html#query_Query-stream).  Built on top of [stream-worker](https://github.com/goodeggs/stream-worker).
 
 ```js


### PR DESCRIPTION
Considering deprecating this package, as it provides only a very thin layer on top of stream-worker, increasing the set of project dependencies without provide significant additional value.